### PR TITLE
add initial vagrant configuration for blazegraph 1.5.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.vagrant
+downloads
+*~
+.DS_STORE

--- a/README.md
+++ b/README.md
@@ -19,7 +19,17 @@ You can shell into the machine with `vagrant ssh` or `ssh -p 2222 vagrant@localh
 * Ubuntu 14.04 64-bit machine with:
   * [Blazegraph 1.5.3](http://sourceforge.net/projects/bigdata/files/bigdata/1.5.3/) at [http://localhost:9999/bigdata/](http://localhost:9999/bigdata/)
   * (more soon)
-  
+
+## Windows Troubleshooting
+
+If you receive errors involving `\r` (end of line):
+
+Edit the global `.gitconfig` file by running the command:
+```
+git config --global core.autocrlf false
+```
+Remove and clone again. This will prevent windows git clients from automatically replacing unix line endings LF with windows line endings CRLF. 
+
 ## Thanks
 
 * This VM setup was heavily influenced (read: stolen) from [Fedora 4 Vagrant](https://github.com/fcrepo4-exts/fcrepo4-vagrant).

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,26 @@
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # All Vagrant configuration is done here. The most common configuration
+  # options are documented and commented below. For a complete reference,
+  # please see the online documentation at vagrantup.com.
+  config.vm.hostname = "blazegraph"
+
+  config.vm.box = "ubuntu/trusty64"
+  # Below needed for Vagrant versions < 1.6.x
+  # config.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
+
+  config.vm.network :forwarded_port, guest: 9999, host: 9999 # Blazegraph
+
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 2048
+  end
+
+  shared_dir = "/vagrant"
+
+  config.vm.provision "shell", path: "./install_scripts/bootstrap.sh", args: shared_dir
+  config.vm.provision "shell", path: "./install_scripts/java.sh", args: shared_dir
+  config.vm.provision "shell", path: "./install_scripts/blazegraph.sh", args: shared_dir
+
+end

--- a/install_scripts/blazegraph.sh
+++ b/install_scripts/blazegraph.sh
@@ -1,0 +1,20 @@
+echo "Installing Blazegraph"
+
+SHARED_DIR=$1
+
+if [ -f "$SHARED_DIR/install_scripts/config" ]; then
+  . $SHARED_DIR/install_scripts/config
+fi
+
+if [ ! -f "$DOWNLOAD_DIR/bigdata-bundled.jar" ]; then
+  echo -n "Downloading Blazegraph..."
+  wget --no-verbose -O "$DOWNLOAD_DIR/bigdata-bundled.jar" "http://iweb.dl.sourceforge.net/project/bigdata/bigdata/$BLAZEGRAPH_VERSION/bigdata-bundled.jar"
+  echo " done"
+fi
+
+cd $DOWNLOAD_DIR
+
+chown -hR vagrant:vagrant bigdata-bundled.jar
+
+echo "Starting Blazegraph"
+java -server -Xmx1g -jar bigdata-bundled.jar > /dev/null &

--- a/install_scripts/bootstrap.sh
+++ b/install_scripts/bootstrap.sh
@@ -1,0 +1,46 @@
+###
+# BASICS
+###
+
+SHARED_DIR=$1
+
+if [ -f "$SHARED_DIR/install_scripts/config" ]; then
+  . $SHARED_DIR/install_scripts/config
+fi
+
+cd $HOME_DIR
+
+# Update
+apt-get -y update && apt-get -y upgrade
+
+# SSH
+apt-get -y install openssh-server
+
+# Build tools
+apt-get -y install build-essential
+apt-get -y install libgmp3-dev #fixes https://github.com/flori/json/issues/253
+apt-get -y install libreadline-dev libyaml-dev libsqlite3-dev libqtwebkit-dev
+
+# Git vim
+apt-get -y install git vim
+
+# Wget and curl
+apt-get -y install wget curl
+
+# More helpful packages
+apt-get -y install htop tree zsh fish
+
+# NodeJS
+# apt-get -y install nodejs
+
+# Postgresql
+# apt-get -y install postgresql
+# apt-get -y install libpq-dev
+
+# Image Magick
+# apt-get -y install imagemagick
+
+# Ffmpeg
+# sudo add-apt-repository ppa:mc3man/trusty-media
+# sudo apt-get update
+# sudo apt-get install -y ffmpeg

--- a/install_scripts/config
+++ b/install_scripts/config
@@ -1,0 +1,15 @@
+#!/bin/sh
+#
+# Contain Environment variables for installs
+#
+
+HOME_DIR="/home/vagrant"
+
+SHARED_DIR="/vagrant"
+
+DOWNLOAD_DIR="$SHARED_DIR/downloads"
+if [ ! -d $DOWNLOAD_DIR ]; then
+  mkdir $DOWNLOAD_DIR
+fi
+
+BLAZEGRAPH_VERSION=1.5.3

--- a/install_scripts/java.sh
+++ b/install_scripts/java.sh
@@ -1,0 +1,5 @@
+###
+# Java
+###
+
+apt-get -y install openjdk-7-jre


### PR DESCRIPTION
- update README to include git config update needed for windows users
- and config files needed for blazegraph 1.5.3
- java 7 JRE install
